### PR TITLE
where clause on update items convert fav. to bool

### DIFF
--- a/tartarus/tartarus/models/Order.py
+++ b/tartarus/tartarus/models/Order.py
@@ -33,7 +33,7 @@ class Order:
         self.__items = items
         self.__totalPrice = totalPrice
         self.__status = self.convert_status(status)
-        self.__favorite = favorite
+        self.__favorite = favorite == True
 
     @classmethod
     def fromID(cls, id=0):
@@ -141,7 +141,9 @@ class Order:
             db.commit()
     
     def setFavorite(self, favorite:bool):
-        if not favorite == self.__favorite:
+        print("Setting Favorite",favorite, self.__favorite)
+        if not favorite is self.__favorite:
+            print("Not equal, setting")
             self.__favorite = favorite
             db = get_db()
             cur = db.cursor()
@@ -164,7 +166,7 @@ class Order:
             db = get_db()
             cur = db.cursor()
             print(type(self.getId()))
-            res = cur.execute(f"UPDATE Orders SET items = ?, totalPrice = ?",(json.dumps(items),self.__totalPrice, )).fetchall()
+            res = cur.execute(f"UPDATE Orders SET items = ?, totalPrice = ? WHERE OrderId = ?",(json.dumps(items),self.__totalPrice, self.getId())).fetchall()
             item = cur.execute(f"SELECT * FROM Orders where OrderId = ?", (self.getId(),)).fetchone()
             cur.close()
             db.commit()

--- a/tartarus/tartarus/orders.py
+++ b/tartarus/tartarus/orders.py
@@ -206,7 +206,7 @@ def update_order():
         error = "Insufficient Privileges"
     if status == 200:
         try:
-            order.setFavorite(data["Favorite"])
+            order.setFavorite(bool(data["Favorite"]))
             order.setItems(data["Items"])
             order.setStatus(data["Status"])
         except TartarusException as t:


### PR DESCRIPTION
Added Fix for both type of favorite as well as edit cart edits all orders

- For the favorite, it looks like sqllite stores booleans as just a single bit, which comes out as an integer. I just needed to update the constructor for the Order class to convert anything it's given to a boolean value.
-  For the editing your cart changes all orders, it looks like I didn't have a where clause on the update items method's sql. Now it has one and shouldn't accidentally update all other orders.